### PR TITLE
Decoder: Add callback API

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -289,7 +289,7 @@ impl<'a> Decoder<'a> {
                 FieldRepresentation::Indexed => {
                     let ((name, value), consumed) =
                         try!(self.decode_indexed(buffer_leftover));
-                    cb(Cow::Owned(name), Cow::Owned(value));
+                    cb(Cow::Borrowed(name), Cow::Borrowed(value));
 
                     consumed
                 },
@@ -348,13 +348,13 @@ impl<'a> Decoder<'a> {
 
     /// Decodes an indexed header representation.
     fn decode_indexed(&self, buf: &[u8])
-            -> Result<((Vec<u8>, Vec<u8>), usize), DecoderError> {
+            -> Result<((&[u8], &[u8]), usize), DecoderError> {
         let (index, consumed) = try!(decode_integer(buf, 7));
         debug!("Decoding indexed: index = {}, consumed = {}", index, consumed);
 
         let (name, value) = try!(self.get_from_table(index));
 
-        Ok(((name.to_vec(), value.to_vec()), consumed))
+        Ok(((name, value), consumed))
     }
 
     /// Gets the header (name, value) pair with the given index from the table.

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -20,6 +20,30 @@
 //!     (b":path".to_vec(), b"/".to_vec()),
 //! ]);
 //! ```
+//!
+//! A more complex example where the callback API is used, providing the client a
+//! borrowed representation of each header, rather than an owned representation.
+//!
+//! ```rust
+//! use hpack::Decoder;
+//! let mut decoder = Decoder::new();
+//!
+//! let mut count = 0;
+//! let header_list = decoder.decode_with_cb(&[0x82, 0x84], |name, value| {
+//!     count += 1;
+//!     match count {
+//!         1 => {
+//!             assert_eq!(&name[..], &b":method"[..]);
+//!             assert_eq!(&value[..], &b"GET"[..]);
+//!         },
+//!         2 => {
+//!             assert_eq!(&name[..], &b":path"[..]);
+//!             assert_eq!(&value[..], &b"/"[..]);
+//!         },
+//!         _ => panic!("Did not expect more than two headers!"),
+//!     };
+//! });
+//! ```
 
 use std::num::Wrapping;
 use std::borrow::Cow;


### PR DESCRIPTION
This pull request adds a new API for performing header decoding, a `decode_with_cb` method on the `Decoder`. It refactors the existing `decode` method to work in terms of this one, while maintaining the same old API and functionality.

The `decode_with_cb` method allows clients to register a callback, which will be given the headers as they are decoded from the buffer. The representation of the headers' names and values is a `Cow<[u8]>`. This way, the decoder does not allocate a new buffer for each header, but rather passes their borrowed representation to the callback, allowing the client to decide whether it should be copied or handled another way.

---
The `Decoder` still performs allocations in two places:

- When decoding a Huffman-encoded string literal -- a new buffer to contain its decoded representation is allocated.
- When adding a new header to the internal dynamic header table -- each entry in the table is represented as an owned byte buffer.